### PR TITLE
BE-3: Update server to use local port 4000

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -23,7 +23,7 @@ const server = http.createServer((req, res) => {
   })
 })
 
-const PORT = 3000
+const PORT = 4000
 const HOST = 'localhost'
 
 server.listen(PORT, HOST, () => {


### PR DESCRIPTION
Both backend and frontend local ports are running on localhost:3000 - this does not allow development. Update the backend port to use 4000.